### PR TITLE
Fix routing key payload in S3EventReader message publishing

### DIFF
--- a/artifacts/aws/lambda/S3EventReader/index.ts
+++ b/artifacts/aws/lambda/S3EventReader/index.ts
@@ -1,8 +1,8 @@
 import { S3Event } from 'aws-lambda';
 import { connect } from 'amqplib';
 
-const RABBITMQ_URL = process.env.RABBITMQ_URL || `amqp://localhost/`;
-const RABBITMQ_EXCHANGE = process.env.RABBITMQ_EXCHANGE || `File`;
+const RABBITMQ_URL = process.env.RABBITMQ_URL ?? `amqp://localhost/`;
+const RABBITMQ_EXCHANGE = process.env.RABBITMQ_EXCHANGE ?? `File`;
 
 export const handler = async (event: S3Event): Promise<string | undefined> => {
   // Get the object from the event and show its content type
@@ -16,7 +16,7 @@ export const handler = async (event: S3Event): Promise<string | undefined> => {
       const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, ` `));
       const routingKey = record.s3.bucket.name + `.` + key.replace(/[/_]/g, `.`);
 
-      if (channel.publish(RABBITMQ_EXCHANGE, routingKey, Buffer.from(key), { persistent: true }))
+      if (channel.publish(RABBITMQ_EXCHANGE, routingKey, Buffer.from(record.s3.bucket.name + "/" + key), { persistent: true }))
         console.log(`Published message to exchange '${RABBITMQ_EXCHANGE}' with key '${routingKey}'`);
       else
         console.error(`Failed to publish message to exchange '${RABBITMQ_EXCHANGE}' with key '${routingKey}'`);


### PR DESCRIPTION
Updated the published message to include both bucket name and key as the payload, ensuring correct data is sent to RabbitMQ. This resolves potential issues with incomplete information in downstream processes.