### PR TITLE
Update Gradle files to standardize plugin usage and configurations

### DIFF
--- a/CommonAPI/build.gradle.kts
+++ b/CommonAPI/build.gradle.kts
@@ -3,6 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
   id("java-library")
   id("jacoco")
+  alias(libs.plugins.spring.boot) apply false
   alias(libs.plugins.sonar)
 }
 

--- a/DataReader/build.gradle.kts
+++ b/DataReader/build.gradle.kts
@@ -3,13 +3,14 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
   id("java")
   id("jacoco")
-  id("org.springframework.boot")
+  alias(libs.plugins.spring.boot)
   alias(libs.plugins.sonar)
 }
 
 description = "Data Reader"
 
 tasks.bootJar {
+  mainClass.set("org.endeavourhealth.im.DataPoller")
   archiveFileName.set("DataReader.jar")
 }
 

--- a/FileReader/build.gradle.kts
+++ b/FileReader/build.gradle.kts
@@ -3,13 +3,14 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
   id("java")
   id("jacoco")
-  id("org.springframework.boot")
+  alias(libs.plugins.spring.boot)
   alias(libs.plugins.sonar)
 }
 
 description = "File Reader"
 
 tasks.bootJar {
+  mainClass.set("org.endeavourhealth.im.FilePoller")
   archiveFileName.set("FileReader.jar")
 }
 

--- a/MessageAPI/build.gradle.kts
+++ b/MessageAPI/build.gradle.kts
@@ -3,6 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
   id("war")
   id("jacoco")
+  alias(libs.plugins.spring.boot)
   alias(libs.plugins.sonar)
 }
 

--- a/SystemAPI/build.gradle.kts
+++ b/SystemAPI/build.gradle.kts
@@ -3,6 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
   id("war")
   id("jacoco")
+  alias(libs.plugins.spring.boot)
   alias(libs.plugins.sonar)
 }
 

--- a/Transform/build.gradle.kts
+++ b/Transform/build.gradle.kts
@@ -3,6 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
   id("java")
   id("jacoco")
+  alias(libs.plugins.spring.boot) apply false
   alias(libs.plugins.sonar)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
 plugins {
   id("java")
-  id("groovy-gradle-plugin")
-  alias(libs.plugins.spring.boot)
-  alias(libs.plugins.spring.dependency)
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=512m
+systemProp.sonar.gradle.skipCompile=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Replaced direct Spring Boot plugin IDs with version catalog aliases and adjusted their application scopes. Updated the Gradle wrapper to version 8.13 for improved compatibility. Added `mainClass` definitions for bootJar tasks and modified properties for Sonar settings.