### PR TITLE
Consolidate and update SonarQube configuration

### DIFF
--- a/CommonAPI/build.gradle.kts
+++ b/CommonAPI/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("java-library")
   id("jacoco")
   alias(libs.plugins.spring.boot) apply false
-  alias(libs.plugins.sonar)
 }
 
 description = "Common API"
@@ -24,25 +23,6 @@ dependencies {
   testImplementation(libs.bundles.spring.test)
 }
 
-if (System.getenv("ENV") == "prod") {
-  tasks.build {
-    finalizedBy("sonar")
-  }
-}
-
-sonar {
-  properties {
-    property("sonar.token", System.getenv("SONAR_LOGIN"))
-    property("sonar.gradle.skipCompile", true)
-    property("sonar.organization", "endeavourhealth-discovery")
-    property("sonar.projectKey", "IMInboundPipeline_API")
-    property("sonar.projectName", "CommonAPI")
-    property("sonar.host.url", "https://sonarcloud.io")
-    property("sonar.junit.reportPaths", "build/test-results/test")
-    property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/errorhandling/**")
-  }
-}
-
 tasks.test {
   jvmArgs("-XX:+EnableDynamicAgentLoading")
   useJUnitPlatform()
@@ -60,6 +40,8 @@ val cucumberRuntime by getConfigurations().creating {
 }
 
 tasks.register("cucumberCli") {
+  group = JavaBasePlugin.VERIFICATION_GROUP
+  description = "Runs Cucumber Feature Files"
   dependsOn("assemble", "testClasses")
   doLast {
     providers.javaexec {

--- a/DataReader/build.gradle.kts
+++ b/DataReader/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("java")
   id("jacoco")
   alias(libs.plugins.spring.boot)
-  alias(libs.plugins.sonar)
 }
 
 description = "Data Reader"
@@ -23,22 +22,6 @@ dependencies {
 
   testImplementation(libs.bundles.junit)
   testImplementation(libs.bundles.spring.test)
-}
-
-if (System.getenv("ENV") == "prod") {
-  tasks.build {
-    finalizedBy("sonar")
-  }
-}
-
-sonar.properties {
-  property("sonar.token", System.getenv("SONAR_LOGIN"))
-  property("sonar.gradle.skipCompile", true)
-  property("sonar.organization", "endeavourhealth-discovery")
-  property("sonar.projectKey", "IMInboundPipeline_Queuereader")
-  property("sonar.projectName", "DataReader")
-  property("sonar.host.url", "https://sonarcloud.io")
-  property("sonar.coverage.exclusions", "**/config/**, **/listener/**, **/model/**,")
 }
 
 tasks.test {

--- a/FileReader/build.gradle.kts
+++ b/FileReader/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("java")
   id("jacoco")
   alias(libs.plugins.spring.boot)
-  alias(libs.plugins.sonar)
 }
 
 description = "File Reader"
@@ -26,23 +25,6 @@ dependencies {
   testImplementation(libs.bundles.junit)
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.bundles.spring.test)
-}
-
-if (System.getenv("ENV") == "prod") {
-  tasks.build {
-    finalizedBy("sonar")
-  }
-}
-
-sonar.properties {
-  property("sonar.token", System.getenv("SONAR_LOGIN"))
-  property("sonar.gradle.skipCompile", true)
-  property("sonar.organization", "endeavourhealth-discovery")
-  property("sonar.projectKey", "IMInboundPipeline_Poller")
-  property("sonar.projectName", "FileReader")
-  property("sonar.host.url", "https://sonarcloud.io")
-  property("sonar.junit.reportPaths", "build/test-results/test")
-  property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/model,**")
 }
 
 tasks.test {

--- a/MessageAPI/build.gradle.kts
+++ b/MessageAPI/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("war")
   id("jacoco")
   alias(libs.plugins.spring.boot)
-  alias(libs.plugins.sonar)
 }
 
 description = "Message API"
@@ -23,23 +22,6 @@ dependencies {
   testImplementation(libs.bundles.junit)
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.bundles.spring.test)
-}
-
-if (System.getenv("ENV") == "prod") {
-  tasks.build {
-    finalizedBy("sonar")
-  }
-}
-
-sonar.properties {
-  property("sonar.token", System.getenv("SONAR_LOGIN"))
-  property("sonar.gradle.skipCompile", true)
-  property("sonar.organization", "endeavourhealth-discovery")
-  property("sonar.projectKey", "IMInboundPipeline_API")
-  property("sonar.projectName", "MessageAPI")
-  property("sonar.host.url", "https://sonarcloud.io")
-  property("sonar.junit.reportPaths", "build/test-results/test")
-  property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/errorhandling/**")
 }
 
 tasks.test {

--- a/SystemAPI/build.gradle.kts
+++ b/SystemAPI/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("war")
   id("jacoco")
   alias(libs.plugins.spring.boot)
-  alias(libs.plugins.sonar)
 }
 
 description = "System API"
@@ -21,23 +20,6 @@ dependencies {
   implementation(libs.bundles.spring)
   implementation(libs.spring.doc)
   implementation(libs.mysql)
-}
-
-if (System.getenv("ENV") == "prod") {
-  tasks.build {
-    finalizedBy("sonar")
-  }
-}
-
-sonar.properties {
-  property("sonar.token", System.getenv("SONAR_LOGIN"))
-  property("sonar.gradle.skipCompile", true)
-  property("sonar.organization", "endeavourhealth-discovery")
-  property("sonar.projectKey", "IMInboundPipeline_API")
-  property("sonar.projectName", "SystemAPI")
-  property("sonar.host.url", "https://sonarcloud.io")
-  property("sonar.junit.reportPaths", "build/test-results/test")
-  property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/errorhandling/**")
 }
 
 tasks.test {
@@ -57,6 +39,8 @@ val cucumberRuntime by getConfigurations().creating {
 }
 
 tasks.register("cucumberCli") {
+  group = JavaBasePlugin.VERIFICATION_GROUP
+  description = "Runs Cucumber Feature Files"
   dependsOn("assemble", "testClasses")
   doLast {
     providers.javaexec {

--- a/Transform/build.gradle.kts
+++ b/Transform/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("java")
   id("jacoco")
   alias(libs.plugins.spring.boot) apply false
-  alias(libs.plugins.sonar)
 }
 
 description = "Transform"
@@ -24,22 +23,6 @@ dependencies {
   testImplementation(libs.bundles.junit)
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.bundles.spring.test)
-}
-
-if (System.getenv("ENV") == "prod") {
-  tasks.build {
-    finalizedBy("sonar")
-  }
-}
-
-sonar.properties {
-  property("sonar.token", System.getenv("SONAR_LOGIN"))
-  property("sonar.gradle.skipCompile", true)
-  property("sonar.organization", "endeavourhealth-discovery")
-  property("sonar.projectKey", "IMInboundPipeline_Transform")
-  property("sonar.projectName", "Transform")
-  property("sonar.host.url", "https://sonarcloud.io")
-  property("sonar.junit.reportPaths", "build/test-results/test")
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("java")
+  alias(libs.plugins.sonar)
 }
 
 repositories {
@@ -9,7 +10,17 @@ repositories {
 java.sourceCompatibility = JavaVersion.VERSION_21
 java.targetCompatibility = JavaVersion.VERSION_21
 
-allprojects {
+sonar {
+  properties {
+    property("sonar.token", System.getenv("SONAR_LOGIN"))
+    property("sonar.host.url", "https://sonarcloud.io")
+    property("sonar.organization", "endeavourhealth-discovery")
+    property("sonar.projectKey", "IMInboundPipeline")
+    property("sonar.projectName", "IM Inbound Pipeline")
+  }
+}
+
+subprojects {
   repositories {
     mavenLocal()
     mavenCentral()
@@ -20,4 +31,55 @@ allprojects {
       url = uri("https://artifactory.endhealth.co.uk/repository/maven-snapshots")
     }
   }
+
+  sonar {
+    properties {
+      property("sonar.sources", "src/main/java")
+      property("sonar.tests", "src/test/java")
+      property("sonar.junit.reportPaths", "build/test-results/test")
+    }
+  }
+}
+
+project(":CommonAPI") {
+  sonar {
+    properties {
+      property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/errorhandling/**")
+    }
+  }
+}
+
+project(":DataReader") {
+  sonar {
+    properties {
+      property("sonar.coverage.exclusions", "**/config/**, **/listener/**, **/model/**,")
+    }
+  }
+}
+
+project(":FileReader") {
+  sonar {
+    properties {
+      property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/model,**")
+    }
+  }
+}
+
+project(":MessageAPI") {
+  sonar {
+    properties {
+      property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/errorhandling/**")
+    }
+  }
+}
+
+project(":SystemAPI") {
+  sonar {
+    properties {
+      property("sonar.coverage.exclusions", "**/config/**, **/controller/**, **/errorhandling/**")
+    }
+  }
+}
+
+project(":Transform") {
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,9 +13,8 @@ slf4j = "1.7.25"
 springDoc = "2.3.0"
 
 [plugins]
-sonar = { id = "org.sonarqube", version = "4.4.1.3373" }
+sonar = { id = "org.sonarqube", version = "6.2.0.5505" }
 spring-boot = { id = "org.springframework.boot", version = "3.4.5" }
-spring-dependency = { id = "io.spring.dependency-management", version = "1.1.7" }
 
 [libraries]
 # Implementation


### PR DESCRIPTION
Moved SonarQube configuration to the root `build.gradle.kts` to centralize management. Removed individual module-specific SonarQube plugins and properties, streamlining the build process. Upgraded SonarQube plugin to version `6.2.0.5505` for improved features and compatibility.