### PR TITLE
Refactor build configurations to centralize Jacoco setup.

### DIFF
--- a/CommonAPI/build.gradle.kts
+++ b/CommonAPI/build.gradle.kts
@@ -2,7 +2,6 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
   id("java-library")
-  id("jacoco")
   alias(libs.plugins.spring.boot) apply false
 }
 
@@ -22,38 +21,3 @@ dependencies {
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.bundles.spring.test)
 }
-
-tasks.test {
-  jvmArgs("-XX:+EnableDynamicAgentLoading")
-  useJUnitPlatform()
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    xml.required.set(true)
-  }
-}
-
-val cucumberRuntime by getConfigurations().creating {
-  extendsFrom(configurations["testImplementation"])
-}
-
-tasks.register("cucumberCli") {
-  group = JavaBasePlugin.VERIFICATION_GROUP
-  description = "Runs Cucumber Feature Files"
-  dependsOn("assemble", "testClasses")
-  doLast {
-    providers.javaexec {
-      mainClass.set("io.cucumber.core.cli.Main")
-      classpath = cucumberRuntime + sourceSets.main.get().output + sourceSets.test.get().output
-      args = listOf(
-        "--plugin", "pretty",
-        "--plugin", "html:build/reports/cucumber/cucumber-report.html",
-        "--glue", "org.endeavourhealth.pipeline.inbound",
-        "src/test/resources"
-      )
-    }
-  }
-}
-

--- a/DataReader/build.gradle.kts
+++ b/DataReader/build.gradle.kts
@@ -1,8 +1,6 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-  id("java")
-  id("jacoco")
   alias(libs.plugins.spring.boot)
 }
 
@@ -22,36 +20,4 @@ dependencies {
 
   testImplementation(libs.bundles.junit)
   testImplementation(libs.bundles.spring.test)
-}
-
-tasks.test {
-  jvmArgs("-XX:+EnableDynamicAgentLoading")
-  useJUnitPlatform()
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    xml.required.set(true)
-  }
-}
-
-val cucumberRuntime by getConfigurations().creating {
-  extendsFrom(configurations["testImplementation"])
-}
-
-tasks.register("cucumberCli") {
-  dependsOn("assemble", "testClasses")
-  doLast {
-    providers.javaexec {
-      mainClass.set("io.cucumber.core.cli.Main")
-      classpath = cucumberRuntime + sourceSets.main.get().output + sourceSets.test.get().output
-      args = listOf(
-        "--plugin", "pretty",
-        "--plugin", "html:build/reports/cucumber/cucumber-report.html",
-        "--glue", "org.endeavourhealth.pipeline.inbound",
-        "src/test/resources"
-      )
-    }
-  }
 }

--- a/FileReader/build.gradle.kts
+++ b/FileReader/build.gradle.kts
@@ -1,8 +1,6 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-  id("java")
-  id("jacoco")
   alias(libs.plugins.spring.boot)
 }
 
@@ -26,36 +24,3 @@ dependencies {
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.bundles.spring.test)
 }
-
-tasks.test {
-  jvmArgs("-XX:+EnableDynamicAgentLoading")
-  useJUnitPlatform()
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    xml.required.set(true)
-  }
-}
-
-val cucumberRuntime by getConfigurations().creating {
-  extendsFrom(configurations["testImplementation"])
-}
-
-tasks.register("cucumberCli") {
-  dependsOn("assemble", "testClasses")
-  doLast {
-    providers.javaexec {
-      mainClass.set("io.cucumber.core.cli.Main")
-      classpath = cucumberRuntime + sourceSets.main.get().output + sourceSets.test.get().output
-      args = listOf(
-        "--plugin", "pretty",
-        "--plugin", "html:build/reports/cucumber/cucumber-report.html",
-        "--glue", "org.endeavourhealth.pipeline.inbound",
-        "src/test/resources"
-      )
-    }
-  }
-}
-

--- a/MessageAPI/build.gradle.kts
+++ b/MessageAPI/build.gradle.kts
@@ -2,7 +2,6 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
   id("war")
-  id("jacoco")
   alias(libs.plugins.spring.boot)
 }
 
@@ -22,36 +21,4 @@ dependencies {
   testImplementation(libs.bundles.junit)
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.bundles.spring.test)
-}
-
-tasks.test {
-  jvmArgs("-XX:+EnableDynamicAgentLoading")
-  useJUnitPlatform()
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    xml.required.set(true)
-  }
-}
-
-val cucumberRuntime by getConfigurations().creating {
-  extendsFrom(configurations["testImplementation"])
-}
-
-tasks.register("cucumberCli") {
-  dependsOn("assemble", "testClasses")
-  doLast {
-    providers.javaexec {
-      mainClass.set("io.cucumber.core.cli.Main")
-      classpath = cucumberRuntime + sourceSets.main.get().output + sourceSets.test.get().output
-      args = listOf(
-        "--plugin", "pretty",
-        "--plugin", "html:build/reports/cucumber/cucumber-report.html",
-        "--glue", "org.endeavourhealth.pipeline.inbound",
-        "src/test/resources"
-      )
-    }
-  }
 }

--- a/SystemAPI/build.gradle.kts
+++ b/SystemAPI/build.gradle.kts
@@ -2,7 +2,6 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
   id("war")
-  id("jacoco")
   alias(libs.plugins.spring.boot)
 }
 
@@ -20,38 +19,4 @@ dependencies {
   implementation(libs.bundles.spring)
   implementation(libs.spring.doc)
   implementation(libs.mysql)
-}
-
-tasks.test {
-  jvmArgs("-XX:+EnableDynamicAgentLoading")
-  useJUnitPlatform()
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    xml.required.set(true)
-  }
-}
-
-val cucumberRuntime by getConfigurations().creating {
-  extendsFrom(configurations["testImplementation"])
-}
-
-tasks.register("cucumberCli") {
-  group = JavaBasePlugin.VERIFICATION_GROUP
-  description = "Runs Cucumber Feature Files"
-  dependsOn("assemble", "testClasses")
-  doLast {
-    providers.javaexec {
-      mainClass.set("io.cucumber.core.cli.Main")
-      classpath = cucumberRuntime + sourceSets.main.get().output + sourceSets.test.get().output
-      args = listOf(
-        "--plugin", "pretty",
-        "--plugin", "html:build/reports/cucumber/cucumber-report.html",
-        "--glue", "org.endeavourhealth.pipeline.inbound",
-        "src/test/resources"
-      )
-    }
-  }
 }

--- a/Transform/build.gradle.kts
+++ b/Transform/build.gradle.kts
@@ -1,8 +1,6 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-  id("java")
-  id("jacoco")
   alias(libs.plugins.spring.boot) apply false
 }
 
@@ -23,36 +21,4 @@ dependencies {
   testImplementation(libs.bundles.junit)
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.bundles.spring.test)
-}
-
-tasks.test {
-  jvmArgs("-XX:+EnableDynamicAgentLoading")
-  useJUnitPlatform()
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    xml.required.set(true)
-  }
-}
-
-val cucumberRuntime by getConfigurations().creating {
-  extendsFrom(configurations["testImplementation"])
-}
-
-tasks.register("cucumberCli") {
-  dependsOn("assemble", "testClasses")
-  doLast {
-    providers.javaexec {
-      mainClass.set("io.cucumber.core.cli.Main")
-      classpath = cucumberRuntime + sourceSets.main.get().output + sourceSets.test.get().output
-      args = listOf(
-        "--plugin", "pretty",
-        "--plugin", "html:build/reports/cucumber/cucumber-report.html",
-        "--glue", "org.endeavourhealth.pipeline.inbound",
-        "src/test/resources"
-      )
-    }
-  }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("java")
+  id("jacoco")
   alias(libs.plugins.sonar)
 }
 
@@ -20,7 +21,11 @@ sonar {
   }
 }
 
+
 subprojects {
+  apply(plugin = "java")
+  apply(plugin = "jacoco")
+
   repositories {
     mavenLocal()
     mavenCentral()
@@ -29,6 +34,18 @@ subprojects {
     }
     maven {
       url = uri("https://artifactory.endhealth.co.uk/repository/maven-snapshots")
+    }
+  }
+
+  tasks.test {
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+    useJUnitPlatform()
+    finalizedBy("jacocoTestReport")
+  }
+
+  tasks.jacocoTestReport {
+    reports {
+      xml.required.set(true)
     }
   }
 


### PR DESCRIPTION
Moved Jacoco and related test configurations to the root `build.gradle.kts` file and removed redundant configurations from subprojects. This simplifies maintenance and ensures consistent test coverage reporting across all modules.